### PR TITLE
added shift+left click to pan

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Might be useful in responsive applications, to allow desktop users to rotate the
 
 | Property   | Description | Default Value |
 | ---------- | ----------- | ------------- |
-| enabled | Boolean – defines if the Orbit Controls are used | false
+| enabled | Boolean – defines if the Orbit Controls are used | false |
 | target | String – the object the camera is looking at | '' |
 | distance | Number – the distnace of the camera to the target | 1 |
 | enableRotate | Boolean – defines if the camera can be rotated | true |
@@ -29,6 +29,8 @@ Might be useful in responsive applications, to allow desktop users to rotate the
 | maxZoom | Number – maximum zoom value | Infinity |
 | minDistance | Number – minimum distance | 0 |
 | maxDistance | Number – maximum distance | Infinity |
+| vrCamera | String - switch active camera to this one when entering VR mode | '' |
+
 
 ### Installation
 
@@ -39,7 +41,7 @@ Install and use by directly including the [browser files](dist):
 ```html
 <head>
   <title>A-Frame using a Camera with Orbit Controls</title>
-  <script src="https://aframe.io/releases/0.3.0/aframe.min.js"></script>
+  <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
   <script src="https://cdn.rawgit.com/tizzle/aframe-orbit-controls-component/master/dist/aframe-orbit-controls-component.min.js"></script>
 </head>
 
@@ -57,8 +59,20 @@ Install and use by directly including the [browser files](dist):
                 dampingFactor: 0.125;
                 rotateSpeed:0.25;
                 minDistance:3;
-                maxDistance:100;"
+                maxDistance:100;
+                vrCamera: #freelook_camera"
             mouse-cursor="">
+
+        <!-- Use alternative free-look camera in VR mode -->
+        <a-entity
+            id="freelook_camera"
+            camera
+            active="false"
+            position="0 0 5"
+            look-controls
+            mouse-cursor="">
+            
+        </a-entity>
             <a-light light="type: directional; color: #fff; intensity: 0.8;" position="-1 1 0"></a-light>
             <a-light light="type: point; color: #fff; intensity: 0.3;" position="0 5 0"></a-light>
         </a-entity>

--- a/index.js
+++ b/index.js
@@ -75,6 +75,10 @@ AFRAME.registerComponent('orbit-controls', {
         maxDistance: {
             default: Infinity
         },
+        vrCamera: {
+            type: 'string',
+            default: null
+        }
     },
 
     /**
@@ -168,6 +172,7 @@ AFRAME.registerComponent('orbit-controls', {
         this.object = this.el.object3D;
 
         this.targetEl = this.sceneEl.querySelector( this.data.target );
+        if (!this.targetEl) {console.warn('Could not find orbit-control target (' + this.data.target + ') in document. Aborting. '); return;}
         this.target3D = this.targetEl.object3D;
         this.target = this.target3D.position.clone();
 
@@ -215,6 +220,12 @@ AFRAME.registerComponent('orbit-controls', {
         // console.log( 'camera', this.cameraType, this.camera );
         // 0.3.0
         this.sceneEl.addEventListener('render-target-loaded', this.handleRenderTargetLoaded.bind(this) );
+
+        if (this.data.vrCamera && !this.data.alreadyAdddedVRListener) {
+            this.sceneEl.addEventListener('enter-vr', this.onEnterVR.bind(this) );
+            this.sceneEl.addEventListener('exit-vr', this.onExitVR.bind(this) );
+            this.data.alreadyAdddedVRListener=true;
+        }
 
         if( this.canvasEl ) this.addEventListeners();
     },
@@ -282,6 +293,20 @@ AFRAME.registerComponent('orbit-controls', {
         event.preventDefault();
     },
 
+    onEnterVR: function(event){
+        // console.log("entering VR mode");
+
+        this.el.setAttribute('camera', 'active', false);
+        document.querySelector(this.data.vrCamera).setAttribute('camera', 'active', true);
+
+    },
+    onExitVR: function(event){
+        // console.log("leaving  VR mode");
+
+        this.el.setAttribute('camera', 'active', true);
+        document.querySelector(this.data.vrCamera).setAttribute('camera', 'active', false);
+
+    },
 
     // MOUSE
 

--- a/index.js
+++ b/index.js
@@ -289,7 +289,13 @@ AFRAME.registerComponent('orbit-controls', {
 
         if( this.data.enabled === false ) return;
 
-        if ( event.button === this.mouseButtons.ORBIT )
+        if ( event.button === this.mouseButtons.ORBIT && (event.shiftKey || event.ctrlKey) )
+        {
+            if ( this.data.enablePan === false ) return;
+            this.handleMouseDownPan( event );
+            this.state = this.STATE.PAN;
+        }
+        else if ( event.button === this.mouseButtons.ORBIT )
         {
             this.panOffset.set( 0, 0, 0 );
 			if ( this.data.enableRotate === false ) return;


### PR DESCRIPTION
Added Left click+Shift/Ctrl to pan. This is useful for trackpad users who have only two mouse buttons. Note this key combo had to be at the top of the IF structure so that it takes precedence over vanilla left-click.

Added vrCamera parameter so you can specify an alternative camera that becomes active in VR mode. Since the orbit cam concept doesn't work so well in VR mode it can be nice to switch to a camera with look-controls in VR mode. Updated README with an example. Admittedly, switching cameras on enter-vr and exit-vr events can be done by the user, but I figured this will be a very common desire (since the orbit-cam concept doenst work so well in VR mode) that it is worthwhile to add this functionality.




