### PR TITLE
Update npm module name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ Install and use by directly including the [browser files](dist):
 Install via npm:
 
 ```bash
-npm install aframe-orbit-controls-component
+npm install aframe-orbit-controls-component-2
 ```
 
 Then register and use.
 
 ```js
 require('aframe');
-require('aframe-orbit-controls-component');
+require('aframe-orbit-controls-component-2');
 ```


### PR DESCRIPTION
I tried installing this component via npm and the one you have in README.md is the wrong module: [aframe-orbit-controls-component](https://www.npmjs.com/package/aframe-orbit-controls-component).

Changed to link to correct module name [aframe-orbit-controls-component-2](https://www.npmjs.com/package/aframe-orbit-controls-component-2).