### PR TITLE
option to automatically switch to look-controls in VR mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## aframe-orbit-controls-component
 
 A (almost) direct port of the ThreeJS Orbit Controls for [A-Frame](https://aframe.io).
-It allows users to rotate the camera around an object. Might be useful as a fallback to VR mode.
+It allows users to rotate the camera around an object. Might be useful as a fallback to VR mode. Automatically switches to look-controls in VR mode.
 
 Have a look at the [examples](https://tizzle.github.io/aframe-orbit-controls-component/)
 
@@ -34,7 +34,7 @@ Have a look at the [examples](https://tizzle.github.io/aframe-orbit-controls-com
 | rotateTo | Vector3 – position to rotate automatically to | '0 0 0' |
 | rotateToSpeed | Number – rotateTo speed | 0.05 |
 | logPosition | Boolean – prints out camera position to console.log() when rotating | true |
-
+| autoVRLookCam | Boolean - automatically switch over to look-controls in VR mode? | true |
 
 ### Installation
 
@@ -45,7 +45,7 @@ Install and use by directly including the [browser files](dist):
 ```html
 <head>
   <title>A-Frame using a Camera with Orbit Controls</title>
-  <script src="https://aframe.io/releases/0.3.0/aframe.min.js"></script>
+  <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
   <script src="https://cdn.rawgit.com/tizzle/aframe-orbit-controls-component/v0.1.6/dist/aframe-orbit-controls-component.min.js"></script>
 </head>
 
@@ -105,3 +105,9 @@ Then register and use.
 require('aframe');
 require('aframe-orbit-controls-component-2');
 ```
+
+Alternatively, include as a `<script>` tag:
+```
+<script src="https://cdn.rawgit.com/tizzle/aframe-orbit-controls-component/v0.1.6/dist/aframe-orbit-controls-component.min.js"></script>
+```
+When the user enters VR mode, `orbit-controls` will pause itself and switch to the `look-controls` attached to the same camera. If no `look-controls` is specified on the current camera, one will be created with the default settings (this usually works fine). If you do not want this behaviour (probably becuase you want to control the camera juggling behaviour yourself) just specify `autoVRLookCam:false`.

--- a/index.js
+++ b/index.js
@@ -89,6 +89,10 @@ AFRAME.registerComponent('orbit-controls', {
     logPosition: {
       type: 'boolean',
       default: false
+    },
+    autoVRLookCam: {
+      type: 'boolean',
+      default: true
     }
   },
 
@@ -108,18 +112,19 @@ AFRAME.registerComponent('orbit-controls', {
 
     // Find the look-controls component on this camera, or create if it doesn't exist.
     this.lookControls = null;
-    if (this.el.components["look-controls"]) {
-      this.lookControls = this.el.components["look-controls"];
-    } else {
-      this.el.setAttribute('look-controls','');
-      this.lookControls = this.el.components["look-controls"];
+    if (this.data.autoVRLookCam) {
+      if (this.el.components["look-controls"]) {
+        this.lookControls = this.el.components["look-controls"];
+      } else {
+        this.el.setAttribute('look-controls','');
+        this.lookControls = this.el.components["look-controls"];
+      }
+      this.lookControls.pause();
+
+      // Attach listeners to pause myself on enter-vr and resume myself on exit-vr
+      this.el.sceneEl.addEventListener('enter-vr', this.handleEnterVR.bind(this));
+      this.el.sceneEl.addEventListener('exit-vr', this.handleExitVR.bind(this));
     }
-    this.lookControls.pause();
-
-
-    // Attach listeners to pause myself on enter-vr and resume myself on exit-vr
-    this.el.sceneEl.addEventListener('enter-vr', this.handleEnterVR.bind(this));
-    this.el.sceneEl.addEventListener('exit-vr', this.handleExitVR.bind(this));
 
 
     this.dolly = new THREE.Object3D();


### PR DESCRIPTION

Added an option (default:true) to automatically switch to look-controls when the user enters VR mode with a HMD. 

IMHO this is an intuitive and default way to handle VR mode. Folks can set autoVRLookCam:false if they prefer to handle the camera in VR  differently. But as it stands, orbit-cam doesn't work in VR.

I also made a camera juggler to handle going in/out of VR mode on desktop and mobile
https://github.com/morandd/dans-aframe-camera-juggler

but with this change, this juggler is not necessary.


