### PR TITLE
fix default rotateTo vec3 to suit AFrame

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ AFRAME.registerComponent('orbit-controls', {
     },
     rotateTo: {
       type: 'vec3',
-      default: '0 0 0'
+      default: [0,0,0]
     },
     rotateToSpeed: {
       type: 'number',


### PR DESCRIPTION
"0 0 0" throws a warning. I hope/think [0,0,0] is more correct.