### PR TITLE
Checking canvasEl exists before removing eventlisteners

### DIFF
--- a/index.js
+++ b/index.js
@@ -343,18 +343,21 @@ AFRAME.registerComponent('orbit-controls', {
    * Remove event listeners
    */
   removeEventListeners: function () {
-    this.canvasEl.removeEventListener('contextmenu', this.onContextMenu, false);
-    this.canvasEl.removeEventListener('mousedown', this.onMouseDown, false);
-    this.canvasEl.removeEventListener('mousewheel', this.onMouseWheel, false);
-    this.canvasEl.removeEventListener('MozMousePixelScroll', this.onMouseWheel, false); // firefox
 
-    this.canvasEl.removeEventListener('touchstart', this.onTouchStart, false);
-    this.canvasEl.removeEventListener('touchend', this.onTouchEnd, false);
-    this.canvasEl.removeEventListener('touchmove', this.onTouchMove, false);
+    if(this.canvasEl){
+        this.canvasEl.removeEventListener('contextmenu', this.onContextMenu, false);
+        this.canvasEl.removeEventListener('mousedown', this.onMouseDown, false);
+        this.canvasEl.removeEventListener('mousewheel', this.onMouseWheel, false);
+        this.canvasEl.removeEventListener('MozMousePixelScroll', this.onMouseWheel, false); // firefox
 
-    this.canvasEl.removeEventListener('mousemove', this.onMouseMove, false);
-    this.canvasEl.removeEventListener('mouseup', this.onMouseUp, false);
-    this.canvasEl.removeEventListener('mouseout', this.onMouseUp, false);
+        this.canvasEl.removeEventListener('touchstart', this.onTouchStart, false);
+        this.canvasEl.removeEventListener('touchend', this.onTouchEnd, false);
+        this.canvasEl.removeEventListener('touchmove', this.onTouchMove, false);
+
+        this.canvasEl.removeEventListener('mousemove', this.onMouseMove, false);
+        this.canvasEl.removeEventListener('mouseup', this.onMouseUp, false);
+        this.canvasEl.removeEventListener('mouseout', this.onMouseUp, false);
+    }
 
     window.removeEventListener('keydown', this.onKeyDown, false);
   },


### PR DESCRIPTION
In certain cases, especially when using React, the canvasEl may have been removed before removeEventListeners gets called. I’ve added a check for this so errors aren’t thrown if this is the case.